### PR TITLE
add example of getting and setting tracked properties

### DIFF
--- a/app/components/example3.hbs
+++ b/app/components/example3.hbs
@@ -1,0 +1,1 @@
+<h1>The list has {{this.list.items.length}} items</h1>

--- a/app/components/example3.js
+++ b/app/components/example3.js
@@ -1,0 +1,48 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+class BrokenList {
+  @tracked items = [];
+
+  constructor(showFruit = false, showAnimals = false, showComputers = false) {
+    if (showFruit) {
+      // this will error as we're getting and setting the tracked property
+      this.items = [...this.items, "Apple"]; 
+    }
+
+    if (showAnimals) {
+      this.items = [...this.items, "Dog"]; 
+    }
+
+    if (showComputers) {
+      this.items = [...this.items, "Mac"]; 
+    }
+  }
+}
+
+class WorkingList {
+  @tracked items = [];
+
+  constructor(showFruit = false, showAnimals = false, showComputers = false) {
+    let items = [];
+    if (showFruit) {
+      items = [...items, "Apple"]; 
+    }
+
+    if (showAnimals) {
+      items = [...items, "Dog"]; 
+    }
+
+    if (showComputers) {
+      items = [...items, "Mac"]; 
+    }
+
+    // this works as we're not getting and setting, just setting
+    this.items = items;
+  }
+}
+
+export default class Example3 extends Component {
+  // @tracked list = new BrokenList(true, true, true);
+  @tracked list = new WorkingList(true, true, true);
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -5,3 +5,7 @@
 <ToggleContent @title="Performing a @task in the constructor" @subtitle="This works in Ember 3.21, errors in 3.22">
   <Example2 />
 </ToggleContent>
+
+<ToggleContent @title="WorkingList works, BrokenList is broken" @subtitle="We should avoid getting and setting tracked properties in functions">
+  <Example3 />
+</ToggleContent>


### PR DESCRIPTION
Here's an example of a class of error that I'm seeing when trying to upgrade to Ember 3.22.

The following method of updating the tracked array fails as we're getting and setting the tracked property:

```js
class BrokenList {
  @tracked items = [];

  constructor(showFruit = false, showAnimals = false) {
    if (showFruit) {
      // this will error as we're getting and setting the tracked property
      this.items = [...this.items, "Apple"]; 
    }

    if (showAnimals) {
      this.items = [...this.items, "Dog"]; 
    }
  }
}
```

If we change the constructor to avoid reading the `@tracked` property, we can avoid the error:

```js
class WorkingList {
  @tracked items = [];

  constructor(showFruit = false, showAnimals = false) {
    let items = [];
    if (showFruit) {
      items = [...items, "Apple"]; 
    }

    if (showAnimals) {
      items = [...items, "Dog"]; 
    }

    // this works as we're not getting and setting, just setting
    this.items = items;
  }
}
```