### PR TITLE
example of <Input> backtracking error when using `@disabled` and on `blur`

### DIFF
--- a/app/components/note-classic.hbs
+++ b/app/components/note-classic.hbs
@@ -1,0 +1,7 @@
+[isFocused: {{this.isFocused}}, isDisabled: {{this.isDisabled}}]
+<br>
+<Textarea
+  @disabled={{this.isDisabled}}
+  class="bg-yellow-200"
+  placeholder="type something then press enter"
+/>

--- a/app/components/note-classic.hbs
+++ b/app/components/note-classic.hbs
@@ -1,7 +1,7 @@
 [isFocused: {{this.isFocused}}, isDisabled: {{this.isDisabled}}]
 <br>
-<Textarea
-  @disabled={{this.isDisabled}}
+<textarea
+  disabled={{this.isDisabled}}
   class="bg-yellow-200"
   placeholder="type something then press enter"
 />

--- a/app/components/note-classic.js
+++ b/app/components/note-classic.js
@@ -1,0 +1,25 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  isFocused: false,
+  isDisabled: false,
+
+  focusIn() {
+    console.log('focusIn');
+    this.set('isFocused', true);
+  },
+  focusOut() {
+    console.log('focusOut');
+    this.set('isFocused', false);
+  },
+
+  keyDown(e) {
+    switch (e.keyCode) {
+      case 13: // Enter
+        console.log('ENTER');
+        e.preventDefault();
+        this.set('isDisabled', true); //this will cause a `focusOut` which will result in a backtracking error
+        break;
+    }
+  },
+});

--- a/app/components/note-octane.hbs
+++ b/app/components/note-octane.hbs
@@ -1,0 +1,10 @@
+[isFocused: {{this.isFocused}}, isDisabled: {{this.isDisabled}}]
+<br>
+<Textarea
+  {{on "keydown" this.onKeyDown}}
+  {{on "focus" this.onFocus}}
+  {{on "blur" this.onBlur}}
+  @disabled={{this.isDisabled}}
+  class="bg-yellow-200"
+  placeholder="type something then press enter"
+/>

--- a/app/components/note-octane.hbs
+++ b/app/components/note-octane.hbs
@@ -1,10 +1,10 @@
 [isFocused: {{this.isFocused}}, isDisabled: {{this.isDisabled}}]
 <br>
-<Textarea
+<textarea
   {{on "keydown" this.onKeyDown}}
   {{on "focus" this.onFocus}}
   {{on "blur" this.onBlur}}
-  @disabled={{this.isDisabled}}
+  disabled={{this.isDisabled}}
   class="bg-yellow-200"
   placeholder="type something then press enter"
 />

--- a/app/components/note-octane.js
+++ b/app/components/note-octane.js
@@ -1,0 +1,31 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class extends Component {
+  @tracked isFocused = false;
+  @tracked isDisabled = false;
+
+  @action
+  onFocus() {
+    console.log('onFocus');
+    this.isFocused = true;
+  }
+
+  @action
+  onBlur() {
+    console.log('onBlur');
+    this.isFocused = false;
+  }
+
+  @action
+  onKeyDown(e) {
+    switch (e.keyCode) {
+      case 13: // Enter
+        console.log('ENTER');
+        e.preventDefault();
+        this.isDisabled = true;
+        break;
+    }
+  }
+};

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,1 +1,8 @@
-...
+<ToggleContent @title="Backtracking error demo: Classic">
+  <NoteClassic />
+</ToggleContent>
+
+<ToggleContent @title="Backtracking error demo: Octane">
+  <NoteOctane />
+</ToggleContent>
+


### PR DESCRIPTION
Here's a minimal example of a failing test that I'm seeing when trying to upgrade my app from Ember 3.21.3 to 3.23.1.

If you type something and press enter, you get the following error in Ember 3.23.1:

<img width="1430" alt="Screenshot 2020-11-27 at 12 24 19" src="https://user-images.githubusercontent.com/2526/100449658-31074400-30ac-11eb-8360-9677078c47c5.png">

There's no error in 3.21, but `isFocused` remains true (which seems surprising):

<img width="1435" alt="Screenshot 2020-11-27 at 12 27 14" src="https://user-images.githubusercontent.com/2526/100449685-3ebcc980-30ac-11eb-8811-bd85b62c1ab1.png">

Similar behaviour happens with classic components.